### PR TITLE
Added 'Tags' auto comment, fixed links

### DIFF
--- a/answers.md
+++ b/answers.md
@@ -1,20 +1,20 @@
 ###[A] Code only answer
-While this code snippet may solve the question, [including an explanation](http://meta.stackexchange.com/questions/114762/explaining-entirely-code-based-answers) really helps to improve the quality of your post. Remember that you are answering the question for readers in the future, and those people might not know the reasons for your code suggestion. Please also try not to crowd your code with explanatory comments, this reduces the readability of both the code and the explanations!
+While this code snippet may solve the question, [including an explanation](//meta.stackexchange.com/questions/114762/explaining-entirely-code-based-answers) really helps to improve the quality of your post. Remember that you are answering the question for readers in the future, and those people might not know the reasons for your code suggestion. Please also try not to crowd your code with explanatory comments, this reduces the readability of both the code and the explanations!
 
 ###[A] Question as answer
-This post isn't an actual attempt at answering the question. Please note [$SITENAME$ doesn't work like a discussion forum](http://$SITEURL$/about), it is a Q&A site where every post is either a question or an answer to a question. Posts can also have [comments](http://$SITEURL$/help/privileges/comment) - small sentences like this one - that can be used to critique or request clarification from an author. This should be either a comment or a [new question](http://$SITEURL$/questions/ask).
+This post isn't an actual attempt at answering the question. Please note [$SITENAME$ doesn't work like a discussion forum](//$SITEURL$/about), it is a Q&A site where every post is either a question or an answer to a question. Posts can also have [comments](//$SITEURL$/help/privileges/comment) - small sentences like this one - that can be used to critique or request clarification from an author. This should be either a comment or a [new question](//$SITEURL$/questions/ask).
 
 ###[A] Me too!
-Please don't add *"Me too"* as an answer. It doesn't actually provide an answer to the question. If you have a different but related question, then [ask](http://$SITEURL$/questions/ask) it (reference this one if it will help provide context). If you're interested in this specific question, you can show your interest by [upvoting](http://$SITEURL$/help/privileges/vote-up) it or leaving a [comment](http://$SITEURL$/help/privileges/comment) once you have enough [reputation](http://$SITEURL$/help/whats-reputation).
+Please don't add *"Me too"* as an answer. It doesn't actually provide an answer to the question. If you have a different but related question, then [ask](//$SITEURL$/questions/ask) it (reference this one if it will help provide context). If you're interested in this specific question, you can show your interest by [upvoting](//$SITEURL$/help/privileges/vote-up) it or leaving a [comment](//$SITEURL$/help/privileges/comment) once you have enough [reputation](//$SITEURL$/help/whats-reputation).
 
 ###[A] Thanks!
-Please don't add _"thanks"_ as answers. They don't actually provide an answer to the question, and can be perceived as noise by its future visitors. Once you [earn](http://meta.stackoverflow.com/q/146472) enough [reputation](http://$SITEURL$/help/whats-reputation), you will gain privileges to [upvote answers](http://$SITEURL$/help/privileges/vote-up) you like. This way future visitors of the question will see a higher vote count on that answer, and the answerer will also be rewarded with reputation points. See [Why is voting important](http://$SITEURL$/help/why-vote).
+Please don't add _"thanks"_ as answers. They don't actually provide an answer to the question, and can be perceived as noise by its future visitors. Once you [earn](//meta.stackoverflow.com/q/146472) enough [reputation](//$SITEURL$/help/whats-reputation), you will gain privileges to [upvote answers](//$SITEURL$/help/privileges/vote-up) you like. This way future visitors of the question will see a higher vote count on that answer, and the answerer will also be rewarded with reputation points. See [Why is voting important](//$SITEURL$/help/why-vote).
 
 ###[A] Comment as answer
-This does not provide an answer to the question. To critique or request clarification from an author, leave a comment below their post. If you [earn](http://meta.stackoverflow.com/q/146472/169503) sufficient [reputation](http://$SITEURL$/help/whats-reputation) you will be able to [comment on any post](http://$SITEURL$/help/privileges/comment).
+This does not provide an answer to the question. To critique or request clarification from an author, leave a comment below their post. If you [earn](//meta.stackoverflow.com/q/146472/169503) sufficient [reputation](//$SITEURL$/help/whats-reputation) you will be able to [comment on any post](//$SITEURL$/help/privileges/comment).
 
 ###[A] Many formatting issues
-Take a moment to read through the [editing help](http://$SITEURL$/editing-help) in the help center. Formatting on $SITENAME$ is different than other sites.
+Take a moment to read through the [editing help](//$SITEURL$/editing-help) in the help center. Formatting on $SITENAME$ is different than other sites.
 
 ###[A] Duplicate link only
 Please don't post link only answers to other $SITENAME$ questions. Instead, vote/flag to close as duplicate, or, if the question is not a duplicate, *tailor the answer to this specific question.*
@@ -23,13 +23,13 @@ Please don't post link only answers to other $SITENAME$ questions. Instead, vote
 Please don't post link only answers to other Stack Exchange questions. Instead, include the essential portions of the answer here, and *tailor the answer to this specific question.*
 
 ###[A] Link only answer
-A link to a potential solution is always welcome, but please [add context around the link](http://meta.stackoverflow.com/a/8259/169503) so your fellow users will have some idea what it is and why it’s there. Always quote the most relevant part of an important link, in case the target site is unreachable or goes permanently offline. Take into account that being _barely more than a link to an external site_ is a possible reason as to [Why and how are some answers deleted?](http://$SITEURL$/help/deleted-answers).
+A link to a potential solution is always welcome, but please [add context around the link](//meta.stackoverflow.com/a/8259/169503) so your fellow users will have some idea what it is and why it’s there. Always quote the most relevant part of an important link, in case the target site is unreachable or goes permanently offline. Take into account that being _barely more than a link to an external site_ is a possible reason as to [Why and how are some answers deleted?](//$SITEURL$/help/deleted-answers).
 
 ###[A] Answering off-topic / bad question
-Please don't post answers on obviously off topic / bad questions! [See: **Should one advise on off topic questions?**](http://meta.stackoverflow.com/q/276572/1768232)
+Please don't post answers on obviously off topic / bad questions! [See: **Should one advise on off topic questions?**](//meta.stackoverflow.com/q/276572/1768232)
 
 ###[A] Code as image
-[Please don't post your code as an image.](http://meta.stackoverflow.com/q/285551/3933332)
+[Please don't post your code as an image.](//meta.stackoverflow.com/q/285551/3933332)
 
 ###[A] Identical answers
 Please don't post identical answers to multiple questions. Post one good answer, then vote/flag to close the other questions as duplicates. If the question is not a duplicate, *tailor your answers to the question.*
@@ -41,19 +41,19 @@ Please use the *Post answer* button only for actual answers. You should [edit] y
 If you have another question, please ask it by clicking the [Ask Question](//$SITEURL$/questions/ask) button.
 
 ###[A] Non English answer
-Please write your answer in English, since [$SITENAME$ is an English site.](http://meta.stackexchange.com/q/13676)
+Please write your answer in English, since [$SITENAME$ is an English site.](//meta.stackexchange.com/q/13676)
 
 ###[A] Self Promotion
-Just linking to your own library or tutorial is not a good answer. Linking to it, explaining why it solves the problem, providing code on how to do so and disclaiming that you wrote it makes for a better answer. See: [**What signifies “Good” self promotion?**](http://meta.stackexchange.com/q/182212/200235)
+Just linking to your own library or tutorial is not a good answer. Linking to it, explaining why it solves the problem, providing code on how to do so and disclaiming that you wrote it makes for a better answer. See: [**What signifies “Good” self promotion?**](//meta.stackexchange.com/q/182212/200235)
 
 ###[A] Language, please
 I know you're excited, but please try to keep your language under control. Think of $SITENAME$ as more like Wikipedia than like Reddit.
 
 ###[A] Borderline Link-Only answer
-This is a borderline [link-only answer](http://meta.stackexchange.com/q/8231/213671). You should expand your answer to include as much information here, and use the link only for reference.
+This is a borderline [link-only answer](//meta.stackexchange.com/q/8231/213671). You should expand your answer to include as much information here, and use the link only for reference.
 
 ###[A] Borderline-spam link answer
-Please be careful with linking to your own content on different sites, you don't want to be a [spammer](http://$SITEURL$/help/promotion). You should be including the majority of the content here, and use the link only as a reference.
+Please be careful with linking to your own content on different sites, you don't want to be a [spammer](//$SITEURL$/help/promotion). You should be including the majority of the content here, and use the link only as a reference.
 
 ###[A] Spam
-Excessive promotion of a specific product/resource may be perceived by the community as **spam**. Take a look at the [help], specially [What kind of behavior is expected of users?](http://$SITEURL$/help/behavior)'s last section: _Avoid overt self-promotion_. You might also be interested in [How do I advertise on $SITENAME$?](http://$SITEURL$/help/advertising).
+Excessive promotion of a specific product/resource may be perceived by the community as **spam**. Take a look at the [help], specially [What kind of behavior is expected of users?](//$SITEURL$/help/behavior)'s last section: _Avoid overt self-promotion_. You might also be interested in [How do I advertise on $SITENAME$?](//$SITEURL$/help/advertising).

--- a/close-reasons.md
+++ b/close-reasons.md
@@ -1,5 +1,5 @@
 ###[C] Legal or Licensing Question
-I'm voting to close this question as off-topic because [licensing advice is off-topic on $SITENAME$.](http://meta.stackoverflow.com/a/274964/1402846) You may be able to get help on [Programmers Stack Exchange, but **read their faq carefully** before proceeding.](http://meta.programmers.stackexchange.com/questions/7265/when-is-a-software-licensing-question-on-topic)
+I'm voting to close this question as off-topic because [licensing advice is off-topic on $SITENAME$.](//meta.stackoverflow.com/a/274964/1402846) You may be able to get help on [Programmers Stack Exchange, but **read their faq carefully** before proceeding.](//meta.programmers.stackexchange.com/questions/7265/when-is-a-software-licensing-question-on-topic)
 
 ###[C] We are not Customer Support
-I'm voting to close this question as off-topic because [we are not customer support for your favorite company](https://meta.stackoverflow.com/questions/255745/).
+I'm voting to close this question as off-topic because [we are not customer support for your favorite company](//meta.stackoverflow.com/questions/255745/).

--- a/edit-summary-answer.md
+++ b/edit-summary-answer.md
@@ -1,11 +1,11 @@
 ###[AQ] i capitalization
-[Capitalize the 1. person sg pronoun](http://english.stackexchange.com/q/172);
+[Capitalize the 1. person sg pronoun](//english.stackexchange.com/q/172);
 
 ###[AQ] it's / its
-[it's and its are different](http://english.stackexchange.com/q/653);
+[it's and its are different](//english.stackexchange.com/q/653);
 
 ###[AQ] Formatting
-[See how you can format and intend your code correctly](http://$SITEURL$/help/formatting);
+[See how you can format and intend your code correctly](//$SITEURL$/help/formatting);
 
 ###[AQ] CAPS
 You don't have to scream;

--- a/edit-summary-question.md
+++ b/edit-summary-question.md
@@ -1,23 +1,23 @@
 ###[EQ] SOLVED!
-Please don't put the answer in your question; You can [self-answer](http://$SITEURL$/help/self-answer) your question if you found the solution;
+Please don't put the answer in your question; You can [self-answer](//$SITEURL$/help/self-answer) your question if you found the solution;
 
 ###[EQ] i capitalization
-[Capitalize the 1. person sg pronoun](http://english.stackexchange.com/q/172);
+[Capitalize the 1. person sg pronoun](//english.stackexchange.com/q/172);
 
 ###[EQ] it's / its
-[it's and its are different](http://english.stackexchange.com/q/653);
+[it's and its are different](//english.stackexchange.com/q/653);
 
 ###[EQ] Formatting
-[See how you can format and intend your code correctly](http://$SITEURL$/help/formatting);
+[See how you can format and intend your code correctly](//$SITEURL$/help/formatting);
 
 ###[EQ] Hi, and thanks!
-[Hi, thanks, ... are considered noise](http://meta.stackexchange.com/q/2950);
+[Hi, thanks, ... are considered noise](//meta.stackexchange.com/q/2950);
 
 ###[EQ] CAPS
 You don't have to scream;
 
 ###[EQ] New question
-If you have a new question, please don't edit it over your old one. [Ask one here](http://$SITEURL$/questions/ask);
+If you have a new question, please don't edit it over your old one. [Ask one here](//$SITEURL$/questions/ask);
 
 ###[EQ] Destroying content
 Please don't destroy content on $SITENAME$;

--- a/edit-summary-question.md
+++ b/edit-summary-question.md
@@ -21,3 +21,6 @@ If you have a new question, please don't edit it over your old one. [Ask one her
 
 ###[EQ] Destroying content
 Please don't destroy content on $SITENAME$;
+
+###[EQ] Tags
+The tags you have been using are not appropriate for this question. Please take the [tour], review [what are tags and how should I use them?](//$SITEURL$/help/tagging) and [edit] your post. Remember to at least read the mouse over on the tags you are using when asking a question. Thank you!;

--- a/edit-summary-question.md
+++ b/edit-summary-question.md
@@ -23,4 +23,4 @@ If you have a new question, please don't edit it over your old one. [Ask one her
 Please don't destroy content on $SITENAME$;
 
 ###[EQ] Tags
-The tags you have been using are not appropriate for this question. Please take the [tour], review [what are tags and how should I use them?](//$SITEURL$/help/tagging) and [edit] your post. Remember to at least read the mouse over on the tags you are using when asking a question. Thank you!;
+The tags you have been using are not appropriate for this question. Please take the [tour], review [what are tags and how should I use them?](//$SITEURL$/help/tagging) and [edit] your post. Remember to at least read the mouse over on the tags you are using when asking a question. Thank you!

--- a/questions.md
+++ b/questions.md
@@ -5,7 +5,7 @@ Please see [ask] and [The perfect question](http://codeblog.jonskeet.uk/2010/08/
 $SITENAME$ is not a free code writing service, please show your code/effort and what the actual problem is.
 
 ###[Q] Many formatting issues
-Take a moment to read through the [editing help](http://$SITEURL$/editing-help) in the help center. Formatting on $SITENAME$ is different than other sites. The better your post looks, the easier it is for others to read and understand it.
+Take a moment to read through the [editing help](//$SITEURL$/editing-help) in the help center. Formatting on $SITENAME$ is different than other sites. The better your post looks, the easier it is for others to read and understand it.
 
 ###[Q] Wrong tags
 The tags you have been using are not appropriate for this question. Please take the [tour], review [what are tags and how should I use them?](//$SITEURL$/help/tagging) and [edit] your post. Remember to at least read the mouse over on the tags you are using when asking a question. Thank you!
@@ -14,7 +14,7 @@ The tags you have been using are not appropriate for this question. Please take 
 Please [edit] your post to include any additional information you have to your question. Avoid adding this in the comments, as they are harder to read and can be deleted easier. The edit button for your post is just below the post's tags.
 
 ###[Q] Code as image
-[Please don't post your code as an image.](http://meta.stackoverflow.com/q/285551/3933332)
+[Please don't post your code as an image.](//meta.stackoverflow.com/q/285551/3933332)
 
 ###[Q] "It doesn't work" with no exception/error details
 Can you elaborate on how your code "doesn't work"? What were you expecting, and what actually happened? If you got an exception/error, post the line it occurred on and the exception/error details. Please [edit] these details in or we may not be able to help.
@@ -23,28 +23,28 @@ Can you elaborate on how your code "doesn't work"? What were you expecting, and 
 There are too many ways to approach this problem. The answers would just turn into a straw-poll for which one people liked. The best thing is to do some research on the topic yourself, find two or three, _analyze_ them, determine if they work for you or not, and _try them out_. Come to us when you have a specific question about something you have attempted to do.
 
 ###[Q] "Why won't it work?" questions with no code
-It seems you have a problem with your code. However, we can't help unless we have [code or information that can reproduce the problem](http://$SITEURL$/help/mcve). Otherwise, we are just blindly guessing.
+It seems you have a problem with your code. However, we can't help unless we have [code or information that can reproduce the problem](//$SITEURL$/help/mcve). Otherwise, we are just blindly guessing.
 
 ###[Q] "Need to make program" but no question
-All that has been posted is a program description. However, we need you to [ask a question](http://$SITEURL$/help/how-to-ask). We can't be sure what you want from us. Please [edit] your post to include a valid question that we can answer. Reminder: make sure you know [what is on-topic here](http://$SITEURL$/help/on-topic), asking us to write the program for you and suggestions are off-topic.
+All that has been posted is a program description. However, we need you to [ask a question](//$SITEURL$/help/how-to-ask). We can't be sure what you want from us. Please [edit] your post to include a valid question that we can answer. Reminder: make sure you know [what is on-topic here](//$SITEURL$/help/on-topic), asking us to write the program for you and suggestions are off-topic.
 
 ###[Q] Need to make changes to existing (missing) code
-We won't know how to make the changes to your existing code base without seeing your original code. Please post [a minimal example of what needs to change](http://$SITEURL$/help/mcve), and fully explain what needs to be modified.
+We won't know how to make the changes to your existing code base without seeing your original code. Please post [a minimal example of what needs to change](//$SITEURL$/help/mcve), and fully explain what needs to be modified.
 
 ###[Q] "Where do I start?" question
-Questions that ask "where do I start" are typically too broad and are not a good fit for this site. People have their own method for approaching the problem and because of this there cannot be a _correct_ answer. Give a good read over [**Where to Start**](http://meta.programmers.stackexchange.com/questions/6366/where-to-start/6367#6367), then address your post.
+Questions that ask "where do I start" are typically too broad and are not a good fit for this site. People have their own method for approaching the problem and because of this there cannot be a _correct_ answer. Give a good read over [**Where to Start**](//meta.programmers.stackexchange.com/questions/6366/where-to-start/6367#6367), then address your post.
 
 ###[Q] More than one question asked
 It is preferred if you can post separate questions instead of combining your questions into one. That way, it helps the people answering your question and also others hunting for at least one of your questions.
 
 ###[Q] Asking for code translation
-$SITENAME$ is a Question and Answer site, not a code translation service. Try to translate the code yourself first, then come to us when you are stuck, making sure to show us [what you have tried](http://$SITEURL$/help/mcve).
+$SITENAME$ is a Question and Answer site, not a code translation service. Try to translate the code yourself first, then come to us when you are stuck, making sure to show us [what you have tried](//$SITEURL$/help/mcve).
 
 ###[Q] Non English question
-Please write your question in English, since [$SITENAME$ is an English site.](http://meta.stackexchange.com/q/13676)
+Please write your question in English, since [$SITENAME$ is an English site.](//meta.stackexchange.com/q/13676)
 
 ###[Q] Software Rec. question
-Unfortunately, questions asking us to recommend or find a book, tool, software library, tutorial or other off-site resource are off-topic here. However, you may find better luck [SoftwareRecs.SE](http://softwarerecs.stackexchange.com/tour). Remember to read [their question requirements](http://softwarerecs.stackexchange.com/help/on-topic) as they are more strict than this site.
+Unfortunately, questions asking us to recommend or find a book, tool, software library, tutorial or other off-site resource are off-topic here. However, you may find better luck [SoftwareRecs.SE](//softwarerecs.stackexchange.com/tour). Remember to read [their question requirements](//softwarerecs.stackexchange.com/help/on-topic) as they are more strict than this site.
 
 ###[Q] CodeReview question
-It seems that your code currently works, and you are looking to improve it. Generally these questions are too opinionated for this site, but you might find better luck at [CodeReview.SE](http://codereview.stackexchange.com/tour). Remember to read [their requirements](http://codereview.stackexchange.com/help/on-topic) as they are a bit more strict than this site.
+It seems that your code currently works, and you are looking to improve it. Generally these questions are too opinionated for this site, but you might find better luck at [CodeReview.SE](//codereview.stackexchange.com/tour). Remember to read [their requirements](//codereview.stackexchange.com/help/on-topic) as they are a bit more strict than this site.

--- a/questions.md
+++ b/questions.md
@@ -7,6 +7,9 @@ $SITENAME$ is not a free code writing service, please show your code/effort and 
 ###[Q] Many formatting issues
 Take a moment to read through the [editing help](http://$SITEURL$/editing-help) in the help center. Formatting on $SITENAME$ is different than other sites. The better your post looks, the easier it is for others to read and understand it.
 
+###[Q] Wrong tags
+The tags you have been using are not appropriate for this question. Please take the [tour], review [what are tags and how should I use them?](//$SITEURL$/help/tagging) and [edit] your post. Remember to at least read the mouse over on the tags you are using when asking a question. Thank you!
+
 ###[Q] Ask OP to edit question instead of adding info in comments
 Please [edit] your post to include any additional information you have to your question. Avoid adding this in the comments, as they are harder to read and can be deleted easier. The edit button for your post is just below the post's tags.
 


### PR DESCRIPTION
## Added comment

Added the following auto comment as edit summary and question:

> The tags you have been using are not appropriate for this question. Please take the [tour], review [what are tags and how should I use them?](//$SITEURL$/help/tagging) and [edit] your post. Remember to at least read the mouse over on the tags you are using when asking a question. Thank you!

## Fixed links

The links in the auto comments did not respect the protocol, linking to the http version of the SE sites. Fixed that so they use the protocol that the user selected, leaving https users on a secure protocol.