### PR TITLE
Added spam auto-comments (and punctuation)

### DIFF
--- a/answers.md
+++ b/answers.md
@@ -1,3 +1,9 @@
+###[A] Spam!!
+This answer is spam. Flag it as spam by ***clicking the "flag" link***!
+
+###[A] Spam!! (Punctuation)
+This answer contains a hidden link in punctuation. It is spam and should be flagged by ***clicking the "flag" link***!
+
 ###[A] Code only answer
 While this code snippet may solve the question, [including an explanation](//meta.stackexchange.com/questions/114762/explaining-entirely-code-based-answers) really helps to improve the quality of your post. Remember that you are answering the question for readers in the future, and those people might not know the reasons for your code suggestion. Please also try not to crowd your code with explanatory comments, this reduces the readability of both the code and the explanations!
 

--- a/questions.md
+++ b/questions.md
@@ -1,3 +1,9 @@
+###[Q] Spam!!
+This question is spam. Flag it as spam by ***clicking the "flag" link*** instead of [voting to close](http://meta.stackoverflow.com/a/295725/4174897)!
+
+###[Q] Spam!! (Punctuation)
+This question contains a hidden link in punctuation. It is spam and should be flagged by ***clicking the "flag" link*** instead of [voting to close](http://meta.stackoverflow.com/a/295725/4174897)!
+
 ###[Q] Ask good!
 Please see [ask] and [The perfect question](http://codeblog.jonskeet.uk/2010/08/29/writing-the-perfect-question/).
 


### PR DESCRIPTION
Spam auto-comments not only kill grace periods but can also provide some guidance for users (click here, don't vtc).

Smokey also recently got the powah to detect "hidden" punctuation links.

This may lead to confusion if it detects punctuation spam that's then promptly deleted, the diamond reviewing the deletion might not see how the post was spam. The `(Punctuation)` auto-comments would clear any confusion in that regard.