### PR TITLE
Suggested boilerplate text for gender assumptions

### DIFF
--- a/sites/stackoverflow.com/questions.md
+++ b/sites/stackoverflow.com/questions.md
@@ -71,5 +71,5 @@ It sounds like you’re going through a really hard time. I’d really like to h
 Questions that ask "please help me" tend to be looking for highly localised guidance, or in some cases, ongoing or private assistance, which is not suited to our Q&A format. It is also rather vague, and is better replaced with a more specific question. Please read [Why is “Can someone help me?” not an actual question?](//meta.stackoverflow.com/questions/284236/why-is-can-someone-help-me-not-an-actual-question).
 
 ###[Q] Gender assumptions of readers
-Hi there. A number of women in our community sometimes say that every time they see gendered assumptions about software engineers, they feel a bit excluded. I wonder, could you try to avoid adding male-oriented greetings and pronouns in your posts, so as to make for a more welcoming environment? Thank you.
+Hi there. A number of folks in our community sometimes say that every time they see gendered assumptions about software engineers, they worry about people feeling excluded. I wonder, could you try to avoid adding male-oriented greetings and pronouns in your posts, so as to make for a more welcoming environment? Thank you.
 

--- a/sites/stackoverflow.com/questions.md
+++ b/sites/stackoverflow.com/questions.md
@@ -67,3 +67,5 @@ It sounds like you’re going through a hard time. I’d really like to help you
 ###[Q] Possible suicide US
 It sounds like you’re going through a really hard time. I’d really like to help you, but unfortunately, we’re not well-equipped to do so here. Your best option is probably to call the [National Suicide Prevention Lifeline](//suicidepreventionlifeline.org/). People are on call there to talk to people struggling with the same kind of issues you are, regardless of location. US: +1-800-273-8255. If calling is not good, they can [chat with you live online](http://suicidepreventionlifeline.org/GetHelp/LifelineChat.aspx). It might not help, but what’s the harm?
 
+###[Q] Gender assumptions of readers
+Hi there. A number of women in our community sometimes say that every time they see gendered assumptions about software engineers, they feel a bit excluded. I wonder, could you try to avoid adding male-oriented greetings and pronouns in your posts, so as to make for a more welcoming environment? Thank you.

--- a/sites/stackoverflow.com/questions.md
+++ b/sites/stackoverflow.com/questions.md
@@ -69,3 +69,4 @@ It sounds like you’re going through a really hard time. I’d really like to h
 
 ###[Q] Gender assumptions of readers
 Hi there. A number of women in our community sometimes say that every time they see gendered assumptions about software engineers, they feel a bit excluded. I wonder, could you try to avoid adding male-oriented greetings and pronouns in your posts, so as to make for a more welcoming environment? Thank you.
+


### PR DESCRIPTION
I tend to use the following text whenever a question refers to readers as "Gents" or "Gentlemen" (or other obviously gendered greeting).

I did think of switching women to "non-men" but that sounded clumsy to my ears, so I suggest this as a rough first version.

(I can't see why this would not merge automatically, I branched from master just now?)
