### PR TITLE
Make markdown links relative without SITEURL

### DIFF
--- a/sites/meta.stackoverflow.com/questions.md
+++ b/sites/meta.stackoverflow.com/questions.md
@@ -1,11 +1,11 @@
 ###[Q] Burnination request
-Thanks for posting this request and allowing the community to weigh in! Please note that burninating a tag is the process of carefully moderating a specific piece of Stack Overflow (please think twice before doing tag-only mass edits, as they can be counter-productive); once the community reaches a consensus, burnination can proceed. For more info, see [What is the process for burninating tags?](https://meta.stackoverflow.com/q/324070).
+Thanks for posting this request and allowing the community to weigh in! Please note that burninating a tag is the process of carefully moderating a specific piece of Stack Overflow (please think twice before doing tag-only mass edits, as they can be counter-productive); once the community reaches a consensus, burnination can proceed. For more info, see [What is the process for burninating tags?](/q/324070).
 
 ###[Q] Burnination request Low Quality
-Please note that burninating a tag is the process of carefully moderating a specific piece of Stack Overflow. Before burnination can proceed your question needs a bit more info on how the tag meets the burnination criteria. For more info, see [What is the process for burninating tags?](https://meta.stackoverflow.com/q/324070).
+Please note that burninating a tag is the process of carefully moderating a specific piece of Stack Overflow. Before burnination can proceed your question needs a bit more info on how the tag meets the burnination criteria. For more info, see [What is the process for burninating tags?](/q/324070).
 
 ###[Q] Meta to Main
-You are on [Meta](https://stackoverflow.com/help/whats-meta). This question will not be answered here and you may want to go over the [Checklist](https://$SITEURL$/q/260648) and [ask] before you repost on main. Please consider deleting this question.
+You are on [Meta](//stackoverflow.com/help/whats-meta). This question will not be answered here and you may want to go over the [Checklist](/q/260648) and [ask] before you repost on main. Please consider deleting this question.
 
 ###[Q] Voting on meta is different
-[Voting on meta is different](https://stackoverflow.com/help/whats-meta). Votes are often used to express (dis)agreement with the general premise of the Meta question. These votes *won't affect* your main site reputation.
+[Voting on meta is different](//stackoverflow.com/help/whats-meta). Votes are often used to express (dis)agreement with the general premise of the Meta question. These votes *won't affect* your main site reputation.

--- a/sites/musicfans.stackexchange.com/questions.md
+++ b/sites/musicfans.stackexchange.com/questions.md
@@ -1,11 +1,11 @@
 ###[Q] ID - No tour, no details
-Hi and welcome. Identification questions need more details to be answerable. Please take the [tour] that will give you the scope of identification questions. [Here](https://musicfans.meta.stackexchange.com/q/350) is a list of relevant details that you should specify.
+Hi and welcome. Identification questions need more details to be answerable. Please take the [tour] that will give you the scope of identification questions. [Here](//musicfans.meta.stackexchange.com/q/350) is a list of relevant details that you should specify.
 
 ###[Q] ID - Tour, no details
-Identification questions need more details to be answerable. [Here](https://musicfans.meta.stackexchange.com/q/350) is a list of relevant details that you should specify.
+Identification questions need more details to be answerable. [Here](//musicfans.meta.stackexchange.com/q/350) is a list of relevant details that you should specify.
 
 ###[Q] ID - No tour, no music (only video description)
-Hi and welcome. Please add more details about the music itself. Please take the [tour] that will give you the scope of identification questions. [Here](https://musicfans.meta.stackexchange.com/q/350) is a list of relevant details that you should specify.
+Hi and welcome. Please add more details about the music itself. Please take the [tour] that will give you the scope of identification questions. [Here](//musicfans.meta.stackexchange.com/q/350) is a list of relevant details that you should specify.
 
 ###[Q] ID - Tour, no music (only video description)
-Please add more details about the music itself. [Here](https://musicfans.meta.stackexchange.com/q/350) is a list of relevant details that you should specify.
+Please add more details about the music itself. [Here](//musicfans.meta.stackexchange.com/q/350) is a list of relevant details that you should specify.

--- a/sites/stackoverflow.com/answers.md
+++ b/sites/stackoverflow.com/answers.md
@@ -1,5 +1,5 @@
 ###[A] Spam
-Excessive promotion of a specific product/resource may be perceived by the community as **spam**. Take a look at the [help], specially [What kind of behavior is expected of users?](//$SITEURL$/help/behavior)'s last section: _Avoid overt self-promotion_. You might also be interested in [How to not be a spammer](//$SITEURL$/help/promotion) and [How do I advertise on $SITENAME$?](//www.stackoverflowbusiness.com/advertising).
+Excessive promotion of a specific product/resource may be perceived by the community as **spam**. Take a look at the [help], specially [What kind of behavior is expected of users?](/help/behavior)'s last section: _Avoid overt self-promotion_. You might also be interested in [How to not be a spammer](/help/promotion) and [How do I advertise on $SITENAME$?](//www.stackoverflowbusiness.com/advertising).
 
 ###[A] Garbage (non-intelligible gibberish or troll meaningless content)
 This is a garbage post by an 1-rep unregistered user without any meaningful contributions. [Flag as "Rude or abusive"](//meta.stackexchange.com/a/58035) to destroy it quickly without poorly seeding the spam detector.
@@ -8,37 +8,37 @@ This is a garbage post by an 1-rep unregistered user without any meaningful cont
 While this code may solve the question, [including an explanation](//meta.stackexchange.com/q/114762) of how and why this solves the problem would really help to improve the quality of your post. Remember that you are answering the question for readers in the future, not just the person asking now. Please [edit] your answer to add explanations and give an indication of what limitations and assumptions apply.
 
 ###[A] Me too!
-Please don't add _Me too!_ as answers. It doesn't actually provide an answer to the question and can be perceived as noise by its future visitors. If you have a different but related question then [ask](//$SITEURL$/questions/ask) it (reference this one if it will help provide context). If you're interested in this specific question, you can [upvote](//$SITEURL$/help/privileges/vote-up) it or leave a [comment](//$SITEURL$/help/privileges/comment) once you have enough [reputation](//$SITEURL$/help/whats-reputation).
+Please don't add _Me too!_ as answers. It doesn't actually provide an answer to the question and can be perceived as noise by its future visitors. If you have a different but related question then [ask](/questions/ask) it (reference this one if it will help provide context). If you're interested in this specific question, you can [upvote](/help/privileges/vote-up) it or leave a [comment](/help/privileges/comment) once you have enough [reputation](/help/whats-reputation).
 
 ###[A] Answers just to say Thanks!
-Please don't add _"thanks"_ as answers. They don't actually provide an answer to the question, and can be perceived as noise by its future visitors. Once you [earn](//meta.stackoverflow.com/q/146472) enough [reputation](//$SITEURL$/help/whats-reputation), you will gain privileges to [upvote answers](//$SITEURL$/help/privileges/vote-up) you like. This way future visitors of the question will see a higher vote count on that answer, and the answerer will also be rewarded with reputation points. See [Why is voting important](//$SITEURL$/help/why-vote).
+Please don't add _"thanks"_ as answers. They don't actually provide an answer to the question, and can be perceived as noise by its future visitors. Once you [earn](//meta.stackoverflow.com/q/146472) enough [reputation](/help/whats-reputation), you will gain privileges to [upvote answers](/help/privileges/vote-up) you like. This way future visitors of the question will see a higher vote count on that answer, and the answerer will also be rewarded with reputation points. See [Why is voting important](/help/why-vote).
 
 ###[A] Begging for answer
 Posting follow-up requests as answers is not effective at attracting answerers. Read [What should I do if no one answers my question?](//stackoverflow.com/help/no-one-answers) for suggestions to get more attention.
 
 ###[A] NAAs by < 50 rep
-This does not provide an answer to the question. You can [search for similar questions](//$SITEURL$/search), or refer to the related and linked questions on the right-hand side of the page to find an answer. If you have a related but different question, [ask a new question](//$SITEURL$/questions/ask), and include a link to this one to help provide context. See: [Ask questions, get answers, no distractions](//$SITEURL$/tour)
+This does not provide an answer to the question. You can [search for similar questions](/search), or refer to the related and linked questions on the right-hand side of the page to find an answer. If you have a related but different question, [ask a new question](/questions/ask), and include a link to this one to help provide context. See: [Ask questions, get answers, no distractions](/tour)
 
 ###[A] NAAs by > 50 rep
-This post doesn't look like an attempt to answer this question. Every post here is expected to be an explicit attempt to *answer* this question; if you have a critique or need a clarification of the question or another answer, you can [post a comment](//$SITEURL$/help/privileges/comment) (like this one) directly below it. Please remove this answer and create either a comment or a new question. See: [Ask questions, get answers, no distractions](//$SITEURL$/tour).
+This post doesn't look like an attempt to answer this question. Every post here is expected to be an explicit attempt to *answer* this question; if you have a critique or need a clarification of the question or another answer, you can [post a comment](/help/privileges/comment) (like this one) directly below it. Please remove this answer and create either a comment or a new question. See: [Ask questions, get answers, no distractions](/tour).
 
 ###[A] Question posted as an answer
-This post isn't an actual attempt at answering the question. Please note [$SITENAME$ doesn't work like a discussion forum](//$SITEURL$/about), it is a Q&A site where every post is either a question or an answer to a question. Posts can also have [comments](//$SITEURL$/help/privileges/comment) — small sentences like this one — that can be used to critique or request clarification from an author. This should be either a comment or a [new question](//$SITEURL$/questions/ask).
+This post isn't an actual attempt at answering the question. Please note [$SITENAME$ doesn't work like a discussion forum](/about), it is a Q&A site where every post is either a question or an answer to a question. Posts can also have [comments](/help/privileges/comment) — small sentences like this one — that can be used to critique or request clarification from an author. This should be either a comment or a [new question](/questions/ask).
 
 ###[A] Many formatting issues (VLQ)
-Please take a moment to read through the [editing help](//$SITEURL$/editing-help) in the [help]. Formatting on $SITENAME$ is different than other sites.
+Please take a moment to read through the [editing help](/editing-help) in the [help]. Formatting on $SITENAME$ is different than other sites.
 
 ###[A] Same answer posted to multiple questions
 Please don't add the same answer to multiple questions. Answer the best one and flag the rest as duplicates. See [Is it acceptable to add a duplicate answer to several questions?](//meta.stackexchange.com/q/104227)
 
 ###[A] Link only (SO link)
-This should be a comment, not an answer. If it is a duplicate question, [vote to close](//stackoverflow.com/help/privileges/close-questions) as such and/or leave a comment once you [earn](//meta.stackoverflow.com/q/146472) enough [reputation](//stackoverflow.com/help/whats-reputation). If not, *tailor the answer to this specific question*.
+This should be a comment, not an answer. If it is a duplicate question, [vote to close](/help/privileges/close-questions) as such and/or leave a comment once you [earn](//meta.stackoverflow.com/q/146472) enough [reputation](/help/whats-reputation). If not, *tailor the answer to this specific question*.
 
 ###[A] Link only (SE link)
 Please don't post link-only answers to other Stack Exchange questions. Instead, include the essential portions of the answer here, and *tailor the answer to this specific question.*
 
 ###[A] Link only
-A link to a solution is welcome, but please ensure your answer is useful without it: [add context around the link](//meta.stackexchange.com/a/8259) so your fellow users will have some idea what it is and why it’s there, then quote the most relevant part of the page you're linking to in case the target page is unavailable. [Answers that are little more than a link may be deleted](//$SITEURL$/help/deleted-answers).
+A link to a solution is welcome, but please ensure your answer is useful without it: [add context around the link](//meta.stackexchange.com/a/8259) so your fellow users will have some idea what it is and why it’s there, then quote the most relevant part of the page you're linking to in case the target page is unavailable. [Answers that are little more than a link may be deleted](/help/deleted-answers).
 
 ###[A] Answering off-topic/bad question
 Please don't post answers on obviously off topic/bad questions! [See: **Should one advise on off topic questions?**](//meta.stackoverflow.com/q/276572)
@@ -50,7 +50,7 @@ Thank you for participating on Stack Overflow. However please note that the ques
 Please don't post answers only pointing out a typographical issue or a missing character. Such answers are unlikely to help future visitors since they are specific to OP's code. Instead, flag or vote to close the question as off-topic as per the [help/on-topic].
 
 ###[A] Data/Code as image
-Please add code and data as text ([using code formatting](//stackoverflow.com/editing-help#code)), not images. Images: A) don't allow us to copy-&-paste the code/errors/data for testing; B) don't permit searching based on the code/error/data contents; and [many more reasons](//meta.stackoverflow.com/a/285557). Images should only be used, in addition to text in code format, if having the image adds something significant that is not conveyed by just the text code/error/data.
+Please add code and data as text ([using code formatting](/editing-help#code)), not images. Images: A) don't allow us to copy-&-paste the code/errors/data for testing; B) don't permit searching based on the code/error/data contents; and [many more reasons](//meta.stackoverflow.com/a/285557). Images should only be used, in addition to text in code format, if having the image adds something significant that is not conveyed by just the text code/error/data.
 
 ###[A] Code improperly edited by non-OP user (Restore code first)
 Edits to other people's code may invalidate questions and answers. Please read [When should I make edits to code?](//meta.stackoverflow.com/q/260245)
@@ -62,13 +62,13 @@ Please write your answer in English, as [$SITENAME$ is an English site.](//meta.
 I know you're excited, but please try to keep your language under control. Think of Stack Overflow as more like Wikipedia than like Reddit.
 
 ###[A] Borderline-spam link answer
-Please be careful with linking to your own content on different sites, you don't want to be a [spammer](//$SITEURL$/help/promotion). You should be including the majority of the content here, and use the link only as a reference.
+Please be careful with linking to your own content on different sites, you don't want to be a [spammer](/help/promotion). You should be including the majority of the content here, and use the link only as a reference.
 
 ###[A] Vandalize your post
 Please don't make more work for other people by vandalizing your posts. By posting on the Stack Exchange network, you've granted a non-revocable right, under a [CC BY-SA license (2.5/3.0/4.0)](//stackoverflow.com/help/licensing), for Stack Exchange to distribute that content (i.e. regardless of your future choices). By Stack Exchange policy, the non-vandalized version of the post is the one which is distributed. Thus, any vandalism will be reverted. If you want to know more about deleting a post please see: [How does deleting work?](//meta.stackexchange.com/q/5221)
 
 ###[A] Profanity
-[Be Nice](//$SITEURL$/help/be-nice). Do not use profanity gratuitously on the site.
+[Be Nice](/help/be-nice). Do not use profanity gratuitously on the site.
 
 ###[A] Offer only 1:1 help
 While helping individuals, we also try to produce a permanent source of future help for others - so answers that produce a tangible record are preferred. Before offering 1:1 help, read [this Meta post](//meta.stackoverflow.com/q/280603) and reconsider making the effort to document the answer. 

--- a/sites/stackoverflow.com/close-reasons.md
+++ b/sites/stackoverflow.com/close-reasons.md
@@ -23,4 +23,4 @@ I'm voting to close this question because questions about [iTunes App Store poli
 I'm voting to close this question because questions about the software development process and software engineering, including quality assurance, architecture & design are off topic on $SITENAME$. You might try posting on [SoftwareEngineering.SE](//meta.stackoverflow.com/a/254571).
 
 ###[C] Intent to hack or scrape from specific site, e.g. YouTube
-I'm voting to close this question as off-topic because question subject and content violate the [StackOverflow Terms of Service sect 3 c) and/or e)](https://stackexchange.com/legal/terms-of-service#3SubscriberContent) by targeting a specific organization with intent to expropriate proprietary data.
+I'm voting to close this question as off-topic because question subject and content violate the [StackOverflow Terms of Service sect 3 c) and/or e)](//stackexchange.com/legal/terms-of-service#3SubscriberContent) by targeting a specific organization with intent to expropriate proprietary data.

--- a/sites/stackoverflow.com/questions.md
+++ b/sites/stackoverflow.com/questions.md
@@ -1,23 +1,23 @@
 ###[Q] Spam
-Excessive promotion of a specific product/resource may be perceived by the community as **spam**. Take a look at the [help], specially [What kind of behavior is expected of users?](//$SITEURL$/help/behavior)'s last section: _Avoid overt self-promotion_. You might also be interested in [How to not be a spammer](//$SITEURL$/help/promotion) and [How do I advertise on $SITENAME$?](//$SITEURL$/help/advertising).
+Excessive promotion of a specific product/resource may be perceived by the community as **spam**. Take a look at the [help], specially [What kind of behavior is expected of users?](/help/behavior)'s last section: _Avoid overt self-promotion_. You might also be interested in [How to not be a spammer](/help/promotion) and [How do I advertise on $SITENAME$?](/help/advertising).
 
 ###[Q] Vandalism
 Please don't make more work for other people by vandalizing your posts. By posting on the Stack Exchange network, you've granted a non-revocable right, under the [CC BY-SA 4.0 license](//creativecommons.org/licenses/by-sa/4.0/), for Stack Exchange to distribute that content (i.e. regardless of your future choices). By Stack Exchange policy, the non-vandalized version of the post is the one which is distributed. Thus, any vandalism will be reverted. If you want to know more about deleting a post please see: [How does deleting work?](//meta.stackexchange.com/q/5221)
 
 ###[Q] Ask good!
-Please see the [ask] help page and [The perfect question](https://codeblog.jonskeet.uk/2010/08/29/writing-the-perfect-question/) blog post by Jon Skeet.
+Please see the [ask] help page and [The perfect question](//codeblog.jonskeet.uk/2010/08/29/writing-the-perfect-question/) blog post by Jon Skeet.
 
 ###[Q] Many formatting issues
-Take a moment to read through the [editing help](//$SITEURL$/editing-help) in the help center. Formatting on $SITENAME$ is different than on other sites. The better your post looks, the easier it is for others to read and understand it.
+Take a moment to read through the [editing help](/editing-help) in the help center. Formatting on $SITENAME$ is different than on other sites. The better your post looks, the easier it is for others to read and understand it.
 
 ###[Q] Wrong tags
-The tags you have been using are not appropriate for this question. Please take the [tour], review [what are tags and how should I use them?](//$SITEURL$/help/tagging) and [edit] your post. Remember to at least read the mouseover on the tags you are using when asking a question.
+The tags you have been using are not appropriate for this question. Please take the [tour], review [what are tags and how should I use them?](/help/tagging) and [edit] your post. Remember to at least read the mouseover on the tags you are using when asking a question.
 
 ###[Q] Ask OP to edit question instead of adding info in comments
 Please [edit] your post to include any additional information you have to your question. Avoid adding this in the comments, as they are harder to read and can be deleted easier. The edit button for your post is just below the post's tags.
 
 ###[Q] Data/Code as image
-Please add code and data as text ([using code formatting](//stackoverflow.com/editing-help#code)), not images. Images: A) don't allow us to copy-&-paste the code/errors/data for testing; B) don't permit searching based on the code/error/data contents; and [many more reasons](//meta.stackoverflow.com/a/285557). Images should only be used, in addition to text in code format, if having the image adds something significant that is not conveyed by just the text code/error/data.
+Please add code and data as text ([using code formatting](/editing-help#code)), not images. Images: A) don't allow us to copy-&-paste the code/errors/data for testing; B) don't permit searching based on the code/error/data contents; and [many more reasons](//meta.stackoverflow.com/a/285557). Images should only be used, in addition to text in code format, if having the image adds something significant that is not conveyed by just the text code/error/data.
 
 ###[Q] Code improperly edited by non-OP user (Restore code first)
 @code-editor Edits to others' code may invalidate questions and answers. Please read [When should I make edits to code?](//meta.stackoverflow.com/q/260245).
@@ -29,7 +29,7 @@ Can you elaborate on how your code "doesn't work"? What were you expecting, and 
 There are too many ways to approach this problem. The answers would just turn into a straw-poll for which one people liked. The best thing is to do some research on the topic yourself, find two or three, _analyze_ them, determine if they work for you or not, and _try them out_. Come to us when you have a specific question about something you have attempted to do.
 
 ###[Q] "Need to make program" but no question
-All that has been posted is a program description, but that doesn't tell us what _problem_ you're having. What have you tried, and what troubles did you encounter? Please [edit] your post to include a [valid question](//$SITEURL$/help/how-to-ask) that we can answer. Reminder: make sure you know what is [on-topic](//$SITEURL$/help/on-topic); asking us to write the program for you, suggestions, and external links are off-topic.
+All that has been posted is a program description, but that doesn't tell us what _problem_ you're having. What have you tried, and what troubles did you encounter? Please [edit] your post to include a [valid question](/help/how-to-ask) that we can answer. Reminder: make sure you know what is [on-topic](/help/on-topic); asking us to write the program for you, suggestions, and external links are off-topic.
 
 ###[Q] Need to make changes to existing (missing) code
 We won't know how to make the changes to your existing code base without seeing your original code. Please post a [mre], and fully explain what needs to be modified.


### PR DESCRIPTION
Using `$SITEURL$` or `https:` isn't necessary in markdown links. 

 - `[link](https://example.com/)` is simpler as a protocol relative link: `[link](//example.com/)`
 - `[link](//$SITEURL/page)` is simpler as a root relative link: `[link](/page)`

This patch changes all URLs to their simplest (shortest) form.